### PR TITLE
Fix excerpt output when outside the loop

### DIFF
--- a/php/class-adapter-post-widget.php
+++ b/php/class-adapter-post-widget.php
@@ -41,6 +41,13 @@ class Adapter_Post_Widget extends \WP_Widget {
 	const NUMBER_OF_POSTS_IN_CAROUSEL = 5;
 
 	/**
+	 * The default excerpt length.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_EXCERPT_LENGTH = 30;
+
+	/**
 	 * Adapter_Post_Widget constructor.
 	 */
 	public function __construct() {
@@ -209,7 +216,7 @@ class Adapter_Post_Widget extends \WP_Widget {
 		 *
 		 * @param int
 		 */
-		$excerpt_length = apply_filters( 'appw_excerpt_length', 30 );
+		$excerpt_length = apply_filters( 'appw_excerpt_length', self::DEFAULT_EXCERPT_LENGTH );
 
 		/**
 		 * The text for the single post preview link, which leads to the URL of the post.
@@ -218,13 +225,23 @@ class Adapter_Post_Widget extends \WP_Widget {
 		 */
 		$link_text = apply_filters( 'appw_link_text', __( 'Read more', 'adapter-post-preview' ) );
 
+		$text = strip_shortcodes( $post->post_content );
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$text = apply_filters( 'the_content', $text );
+		$text = str_replace( ']]>', ']]&gt;', $text );
+
+		/** This filter is documented in wp-includes/formatting.php */
+		$excerpt_more = apply_filters( 'excerpt_more', ' [&hellip;]' );
+		$raw_excerpt  = wp_trim_words( $text, $excerpt_length, $excerpt_more );
+
 		ob_start();
 		?>
 		<div class="post-preview">
 			<?php echo get_the_post_thumbnail( $post->ID, 'medium', array( 'class' => 'img-rounded img-responsive' ) ); ?>
 			<div class="post-title"><h2><?php echo esc_html( get_the_title( $post->ID ) ); ?></h2></div>
 			<div class='center-block excerpt-and-link'>
-				<p><?php echo wp_kses_post( wp_trim_words( get_the_excerpt( $post->ID ), $excerpt_length, '...' ) ); ?></p>
+				<p><?php echo wp_kses_post( wp_trim_words( $raw_excerpt, $excerpt_length, '...' ) ); ?></p>
 				<a class="btn btn-primary btn-med" href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>"><?php echo esc_html( $link_text ); ?></a>
 			</div>
 		</div>

--- a/tests/php/test-class-adapter-post-widget.php
+++ b/tests/php/test-class-adapter-post-widget.php
@@ -135,13 +135,16 @@ class Test_Adapter_Post_Widget extends \WP_UnitTestCase {
 		$this->create_mock_posts();
 
 		// This should display a carousel.
-		$instance = array( Adapter_Post_Widget::SELECTED_POST => Adapter_Post_Widget::DISPLAY_CAROUSEL );
+		$instance     = array( Adapter_Post_Widget::SELECTED_POST => Adapter_Post_Widget::DISPLAY_CAROUSEL );
+		$mock_post_id = end( $this->mock_post_ids );
+		$latest_post  = get_post( $mock_post_id );
 		ob_start();
 		$this->widget->widget( $args, $instance );
 		$output = ob_get_clean();
 		$this->assertContains( $before_widget, $output );
 		$this->assertContains( $after_widget, $output );
 		$this->assertContains( '<div class="carousel-inner">', $output );
+		$this->assertContains( wp_trim_words( $latest_post->post_content ), $output );
 
 		// This should display a single post preview.
 		$mock_post_id = reset( $this->mock_post_ids );
@@ -210,12 +213,13 @@ class Test_Adapter_Post_Widget extends \WP_UnitTestCase {
 		$this->create_mock_posts();
 		$mock_post_id = reset( $this->mock_post_ids );
 		$mock_post    = get_post( $mock_post_id );
+		$content      = $mock_post->post_content;
 		$markup       = $this->widget->get_single_post_preview_markup( $mock_post );
 
 		$expected_thumbnail = get_the_post_thumbnail( $mock_post_id, 'medium', array( 'class' => 'img-rounded img-responsive' ) );
 		$this->assertContains( $expected_thumbnail, $markup );
 		$this->assertContains( '<div class="post-title"><h2>', $markup );
-		$this->assertContains( wp_trim_words( get_the_excerpt( $mock_post_id ), 30, '...' ), $markup );
+		$this->assertContains( wp_trim_words( $content, 30, '...' ), $markup );
 		$this->assertContains( get_permalink( $mock_post_id ), $markup );
 		$this->assertContains( '<a class="btn btn-primary btn-med"', $markup );
 	}


### PR DESCRIPTION
Before, this called `get_the_excerpt()` inside of the loop, using `wp_setup_postdata()`.

But `get_the_excerpt()` on its own doesn't work outside the loop.

So instead, get the content from the `$post`. Then, pass it to `wp_trim_words()`.

This mainly copies the logic from inside `wp_trim_words()`.
