### PR TITLE
Add assertions to get 100% coverage of methods and functions

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -62,17 +62,22 @@ class Plugin {
 	public $classes = array( 'adapter-post-widget', 'carousel' );
 
 	/**
+	 * The instance of this class.
+	 *
+	 * @var Plugin
+	 */
+	public static $instance;
+
+	/**
 	 * Gets the instance of this plugin.
 	 *
 	 * @return Plugin $instance The plugin instance.
 	 */
 	public static function get_instance() {
-		static $instance;
-		if ( ! $instance instanceof Plugin ) {
-			$instance = new Plugin();
+		if ( ! self::$instance instanceof Plugin ) {
+			self::$instance = new Plugin();
 		}
-
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/tests/php/test-class-adapter-post-widget.php
+++ b/tests/php/test-class-adapter-post-widget.php
@@ -154,6 +154,13 @@ class Test_Adapter_Post_Widget extends \WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( get_the_title( $mock_post_id ), $output );
 		$this->assertContains( get_the_permalink( $mock_post_id ), $output );
+
+		// The SELECTED_POST value is incorrect, so this should only output the $before_widget and $after_widget values.
+		$instance = array( Adapter_Post_Widget::SELECTED_POST => true );
+		ob_start();
+		$this->widget->widget( $args, $instance );
+		$output = ob_get_clean();
+		$this->assertEquals( $before_widget . $after_widget, $output );
 	}
 
 	/**

--- a/tests/php/test-class-plugin.php
+++ b/tests/php/test-class-plugin.php
@@ -39,6 +39,11 @@ class Test_Plugin extends \WP_UnitTestCase {
 		$this->assertEquals( Plugin::get_instance(), $this->plugin );
 		$this->assertEquals( __NAMESPACE__ . '\Plugin', get_class( Plugin::get_instance() ) );
 		$this->assertEquals( plugins_url( Plugin::SLUG ), $this->plugin->location );
+
+		// Ensure that get_instance() instantiates Plugin correctly when Plugin::$instance is null.
+		Plugin::$instance = null;
+		$instance         = Plugin::get_instance();
+		$this->assertEquals( Plugin::$instance, $instance );
 	}
 
 	/**


### PR DESCRIPTION
This improves the PHPUnit test coverage to 100% in the `php/` directory. The only other PHP file, [adapter-post-preview.php](https://github.com/kienstra/adapter-post-preview/blob/ce61ba2c62772549ffc2fde43c1c50cb2ba4f671/adapter-post-preview.php), doesn't have any function or method.

Fixes #2.

<img width="1177" alt="coverage-methods" src="https://user-images.githubusercontent.com/4063887/42489670-f8cb5966-83d1-11e8-9f2d-d2b8c675ada3.png">


